### PR TITLE
chore: run ci on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         run: nix run nixpkgs#deadnix -- --fail
 
   flake-check:
-    runs-on: macos-15
+    runs-on: ubuntu-24.04
     needs: lint
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - None

- Chores
  - Expanded CI to run on pushes to main in addition to pull requests.
  - Added a macOS build job that runs on main after evaluations to validate changes end-to-end.
  - Introduced matrix-based builds to cover multiple host configurations in parallel.
  - Improved build transparency with clearer logs and consistent checkout and caching steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->